### PR TITLE
FIX community-list don't are send o frr config

### DIFF
--- a/scripts/frr/configs/commands/policy.json
+++ b/scripts/frr/configs/commands/policy.json
@@ -41,8 +41,8 @@
     "/policy/route/prefix-list6/@element/rule/@element":"ipv6 prefix-list {/../../tagnode/@text} seq {/tagnode/@text} {/action/@text} {/prefix/@text} [ge {/ge/@text},] [le {/le/@text},]",
     "/policy/route/prefix-list6/@element/description":"ipv6 prefix-list {/../tagnode/@text} description {/@text}",
     "/policy/route/access-list/@element":"$acl|{/@dict}$",
-    "/policy/route/community-list/standard/@element/rule/@element":"ip community-list standard {/../../tagnode/@text} {/action/@text} {community/@text}",
-    "/policy/route/community-list/expanded/@element/rule/@element":"ip community-list expanded {/../../tagnode/@text} {/action/@text} {regex/@text}",
-    "/policy/route/extcommunity-list/standard/@element/rule/@element":"ip extcommunity-list standard {/../../tagnode/@text} {/action/@text} [rt {rt/@text},] [soo {soo/@text},]",
-    "/policy/route/extcommunity-list/expanded/@element/rule/@element":"ip extcommunity-list expanded {/../../tagnode/@text} {/action/@text} {regex/@text}"
+    "/policy/route/community-list/standard/@element/rule/@element":"bgp community-list standard {/../../tagnode/@text} {/action/@text} {community/@text}",
+    "/policy/route/community-list/expanded/@element/rule/@element":"bgp community-list expanded {/../../tagnode/@text} {/action/@text} {regex/@text}",
+    "/policy/route/extcommunity-list/standard/@element/rule/@element":"bgp extcommunity-list standard {/../../tagnode/@text} {/action/@text} [rt {rt/@text},] [soo {soo/@text},]",
+    "/policy/route/extcommunity-list/expanded/@element/rule/@element":"bgp extcommunity-list expanded {/../../tagnode/@text} {/action/@text} {regex/@text}"
 }


### PR DESCRIPTION
The version of FRR in DANOS use "bgp community-list ..." command
and not "ip community-list..."