### PR TITLE
FIX config FRR genaration of community-list

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+vyatta-protocols-frr (1.12.5) unstable; urgency=medium
+
+  * Update component to latest library
+  * Add base.conf for config which is always present
+  * Disable kernel nexthop support
+
+ -- Duncan Eastoe <duncan.eastoe@att.com>  Thu, 09 Jul 2020 18:36:09 +0100
+
 vyatta-protocols-frr (1.12.4) unstable; urgency=medium
 
   [ bbs2web ]


### PR DESCRIPTION
In version of frr used by DANOS de command of community-list is "bgp community-list" unless  "ip communty-list"

Signed-off-by: Otavio Augusto <otavioti@gmail.com>