### PR TITLE
add missing exit command for bgp vrf

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,3 @@
-vyatta-protocols-frr (1.15.3) unstable; urgency=medium
-
-  * Provide config for ip nht resolve-via-default
-
- -- James Wheatley <jammy@att.com>  Mon, 10 May 2021 11:42:30 +0100
-
 vyatta-protocols-frr (1.15.2) unstable; urgency=medium
 
   [ Nicholas Brown ]

--- a/scripts/frr/configs/commands/bgp_vrf.json
+++ b/scripts/frr/configs/commands/bgp_vrf.json
@@ -1,5 +1,6 @@
 {
     "/routing/routing-instance/@element/protocols/bgp/@enter": "!",
+    "/routing/routing-instance/@element/protocols/bgp/@exit": "exit",
     "/routing/routing-instance/@element/protocols/bgp/@element": ["router bgp {/tagnode/@text} vrf vrf{/../../../instance-name/@text}", "no bgp default ipv4-unicast"],
     "/routing/routing-instance/@element/protocols/bgp/@element/timers": "timers bgp {/keepalive/@text} {/holdtime/@text}",
 

--- a/scripts/frr/configs/commands/bgp_vrf.json
+++ b/scripts/frr/configs/commands/bgp_vrf.json
@@ -1,6 +1,5 @@
 {
     "/routing/routing-instance/@element/protocols/bgp/@enter": "!",
-    "/routing/routing-instance/@element/protocols/bgp/@exit": "exit",
     "/routing/routing-instance/@element/protocols/bgp/@element": ["router bgp {/tagnode/@text} vrf vrf{/../../../instance-name/@text}", "no bgp default ipv4-unicast"],
     "/routing/routing-instance/@element/protocols/bgp/@element/timers": "timers bgp {/keepalive/@text} {/holdtime/@text}",
 


### PR DESCRIPTION
Add a line in scripts/frr/configs/commands/bgp_vrf.json to avoid commit error.

Error message:

`ERROR: vtysh failed to process new configuration: vtysh (mark file) exited with status 2:
b'line 30: % Unknown command: exit-vrf\n\n'`

Cause:

Generated config file is missing exit statement if use original json file:

`router bgp 65534 vrf vrfblue
no bgp default ipv4-unicast
address-family ipv4 unicast
rd vpn export 65534:120
import vpn
export vpn
rt vpn both 65534:120
exit-address-family
address-family ipv6 unicast
rd vpn export 65534:120
import vpn
export vpn
exit-address-family
 bgp ebgp-requires-policy
bgp log-neighbor-changes
 bgp network import-check
bgp router-id 172.16.0.1
vrf vrfblue
ip nht resolve-via-default
ipv6 nht resolve-via-default
exit-vrf`

After:

`router bgp 65534 vrf vrfblue
no bgp default ipv4-unicast
address-family ipv4 unicast
rd vpn export 65534:120
import vpn
export vpn
rt vpn both 65534:120
exit-address-family
address-family ipv6 unicast
rd vpn export 65534:120
import vpn
export vpn
exit-address-family
 bgp ebgp-requires-policy
bgp log-neighbor-changes
 bgp network import-check
bgp router-id 172.16.0.1
exit
vrf vrfblue
ip nht resolve-via-default
ipv6 nht resolve-via-default
exit-vrf`