### PR TITLE
Add missing line for correctly exit config level

### DIFF
--- a/scripts/frr/configs/commands/bgp_vrf.json
+++ b/scripts/frr/configs/commands/bgp_vrf.json
@@ -1,5 +1,6 @@
 {
     "/routing/routing-instance/@element/protocols/bgp/@enter": "!",
+    "/routing/routing-instance/@element/protocols/bgp/@exit": "exit",
     "/routing/routing-instance/@element/protocols/bgp/@element": ["router bgp {/tagnode/@text} vrf vrf{/../../../instance-name/@text}", "no bgp default ipv4-unicast"],
     "/routing/routing-instance/@element/protocols/bgp/@element/timers": "timers bgp {/keepalive/@text} {/holdtime/@text}",
 


### PR DESCRIPTION
Add a line in scripts/frr/configs/commands/bgp_vrf.json to avoid commit error.

Error message:

```
ERROR: vtysh failed to process new configuration: vtysh (mark file) exited with status 2: b'line 30: % Unknown command: exit-vrf\n\n'
```

Cause:

Generated config file is missing exit statement if use original json file.